### PR TITLE
bug in debug_assert

### DIFF
--- a/random-trait/src/lib.rs
+++ b/random-trait/src/lib.rs
@@ -163,7 +163,7 @@ pub trait Random {
     /// Returns a random `bool` with 50/50 probability.
     fn get_bool(&mut self) -> bool {
         // TODO: More research, least/most significant bit?
-        let bit = self.get_u8() & 0b1000_0000;
+        let bit = self.get_u8() & 0b000_0001;
         debug_assert!(bit < 2);
         bit == 1
     }


### PR DESCRIPTION
This debug_assert was causing me issues, so I just adjusted the value to work with the original intention of the assert. I prefer this over shifting the MSB over, or adjusting the assert to check for 0x00 or 0x80 specifically.